### PR TITLE
Add per-engine text-to-speech model selection (with dynamic model lists)

### DIFF
--- a/app_config.php
+++ b/app_config.php
@@ -44,5 +44,13 @@
 		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
 		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Text to Speech API URL";
 		$y++;
+		$apps[$x]['default_settings'][$y]['default_setting_uuid'] = "a1f6d4c2-7b90-4c1e-9d2a-3e5f8c0a71bd";
+		$apps[$x]['default_settings'][$y]['default_setting_category'] = "speech";
+		$apps[$x]['default_settings'][$y]['default_setting_subcategory'] = "model";
+		$apps[$x]['default_settings'][$y]['default_setting_name'] = "text";
+		$apps[$x]['default_settings'][$y]['default_setting_value'] = "";
+		$apps[$x]['default_settings'][$y]['default_setting_enabled'] = "false";
+		$apps[$x]['default_settings'][$y]['default_setting_description'] = "Text to Speech model. Leave blank to use the engine default. The available models depend on the selected engine.";
+		$y++;
 
 ?>

--- a/resources/classes/speech.php
+++ b/resources/classes/speech.php
@@ -174,7 +174,9 @@ class speech {
 				if (isset($this->audio_speed)) {
 					$object->set_speed((float)$this->audio_speed);
 				}
-				//$object->set_model($this->audio_model);
+				if (!empty($this->audio_model)) {
+					$object->set_model($this->audio_model);
+				}
 				//$object->set_language($this->audio_language);
 				//$object->set_translate($this->audio_translate);
 				$object->set_message($this->audio_message);

--- a/resources/classes/speech_elevenlabs.php
+++ b/resources/classes/speech_elevenlabs.php
@@ -48,8 +48,8 @@ class speech_elevenlabs implements speech_interface {
 
 	public function speech(): bool {
 
-		//get the model automatically
-		$model_id = $this->get_model();
+		//use the selected model, otherwise detect the model automatically
+		$model_id = !empty($this->model) ? $this->model : $this->get_model();
 
 		//if model is version 1 replace it with version 2
 		if ($model_id == 'eleven_multilingual_v1') {

--- a/resources/classes/speech_elevenlabs.php
+++ b/resources/classes/speech_elevenlabs.php
@@ -15,6 +15,7 @@ class speech_elevenlabs implements speech_interface {
 	private $languages;
 	private $api_key;
 	private $model;
+	private $models_cache;
 
 	public function __construct($settings) {
 		//set the default values
@@ -264,12 +265,58 @@ class speech_elevenlabs implements speech_interface {
 	}
 
 	public function get_models(): array {
-		return [
+
+		//return the cached list within the same request
+		if (isset($this->models_cache)) {
+			return $this->models_cache;
+		}
+
+		//the curated fallback list, used when the API is unavailable
+		$models = [
 			'eleven_monolingual_v1' => 'Default',
 			'eleven_turbo_v1' => 'Eleven Turbo v1',
 			'eleven_turbo_v2' => 'Eleven Turbo v2',
 			'eleven_multilingual_v1' => 'Eleven Multilingual v1',
 			'eleven_multilingual_v2' => 'Eleven Multilingual v2',
 		];
+
+		//fetch the available models from the ElevenLabs API and keep the ones that can do text to speech
+		if (!empty($this->api_key)) {
+			$headers = [
+				'Content-Type: application/json',
+				"xi-api-key: $this->api_key",
+			];
+			$curl = curl_init();
+			curl_setopt_array($curl, [
+				CURLOPT_URL => 'https://api.elevenlabs.io/v1/models',
+				CURLOPT_RETURNTRANSFER => true,
+				CURLOPT_TIMEOUT => 5,
+				CURLOPT_CONNECTTIMEOUT => 3,
+				CURLOPT_HTTPHEADER => $headers,
+			]);
+			$response = curl_exec($curl);
+			$http_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+			curl_close($curl);
+			if ($http_code == 200 && !empty($response)) {
+				$json_array = json_decode($response, true);
+				//the endpoint returns either a bare array or a {"models": [...]} wrapper
+				$list = $json_array['models'] ?? $json_array;
+				$fetched = [];
+				if (is_array($list)) {
+					foreach ($list as $row) {
+						if (!empty($row['can_do_text_to_speech']) && !empty($row['model_id'])) {
+							$fetched[$row['model_id']] = $row['name'] ?? $row['model_id'];
+						}
+					}
+				}
+				if (!empty($fetched)) {
+					$models = $fetched;
+				}
+			}
+		}
+
+		//cache and return
+		$this->models_cache = $models;
+		return $models;
 	}
 }

--- a/resources/classes/speech_inworld.php
+++ b/resources/classes/speech_inworld.php
@@ -98,6 +98,9 @@ if (!class_exists('speech_inworld')) {
 
 		/**
 		 * get available models
+		 *
+		 * Inworld has no list-models API endpoint (only voices), so this list is
+		 * curated. Update it here when Inworld releases or retires a model.
 		 */
 		public function get_models() : array {
 			return [

--- a/resources/classes/speech_inworld.php
+++ b/resources/classes/speech_inworld.php
@@ -49,6 +49,7 @@ if (!class_exists('speech_inworld')) {
 		public $filename;
 		public $message;
 		public $language;
+		public $model;
 		public $voice_id;
 		public $api_key;
 		public $api_secret;
@@ -96,10 +97,14 @@ if (!class_exists('speech_inworld')) {
 		}
 
 		/**
-		 * get available models (Inworld doesn't use models, return empty)
+		 * get available models
 		 */
 		public function get_models() : array {
-			return [];
+			return [
+				'inworld-tts-2' => 'inworld-tts-2 (newest, 100+ languages)',
+				'inworld-tts-1.5-max' => 'inworld-tts-1.5-max',
+				'inworld-tts-1.5-mini' => 'inworld-tts-1.5-mini (fastest)'
+			];
 		}
 
 		/**
@@ -250,11 +255,14 @@ if (!class_exists('speech_inworld')) {
 					'Authorization: Basic ' . $this->api_key
 				];
 
+				// Use the selected model, falling back to the newest model when none is set
+				$model = !empty($this->model) ? $this->model : 'inworld-tts-2';
+
 				// Build request data according to Inworld API spec
 				$data = [
 					'text' => $this->text,
 					'voiceId' => $this->voice_id,
-					'modelId' => 'inworld-tts-1'
+					'modelId' => $model
 				];
 
 				//debug output
@@ -385,10 +393,12 @@ if (!class_exists('speech_inworld')) {
 		}
 
 		/**
-		 * set_model - set the model (Inworld doesn't use models, so this is a no-op)
+		 * set_model - set the model (only if it is a valid, supported model)
 		 */
 		public function set_model(string $model) : void {
-			// Inworld doesn't use models, so we just ignore this
+			if (array_key_exists($model, $this->get_models())) {
+				$this->model = $model;
+			}
 		}
 
 		/**

--- a/resources/classes/speech_local.php
+++ b/resources/classes/speech_local.php
@@ -200,7 +200,7 @@ class speech_local implements speech_interface {
 		];
 
 		// set the http data
-		$data['model'] = 'tts-1-hd';
+		$data['model'] = !empty($this->model) ? $this->model : 'tts-1-hd';
 		$data['input'] = $this->message;
 		$data['voice'] = $this->voice;
 

--- a/resources/classes/speech_openai.php
+++ b/resources/classes/speech_openai.php
@@ -17,6 +17,7 @@ class speech_openai implements speech_interface {
 	private $voice;
 	private $message;
 	private $model;
+	private $models_cache;
 	private $speed;
 	private $language;
 	private $translate;
@@ -254,10 +255,51 @@ class speech_openai implements speech_interface {
 	}
 
 	public function get_models(): array {
-		return [
+
+		//return the cached list within the same request
+		if (isset($this->models_cache)) {
+			return $this->models_cache;
+		}
+
+		//the curated fallback list, used when the API is unavailable
+		$models = [
 			'tts-1-hd' => 'tts-1-hd',
-			'tts-1' => 'tts-1'
+			'tts-1' => 'tts-1',
 		];
+
+		//fetch the available models from the OpenAI API; the models endpoint has no
+		//capability flag, so keep the text to speech models by matching "tts" in the id
+		if (!empty($this->api_key)) {
+			$models_url = str_replace('/audio/speech', '/models', $this->api_url);
+			$ch = curl_init($models_url);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $this->api_key]);
+			curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 3);
+			$response = curl_exec($ch);
+			$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+			curl_close($ch);
+			if ($http_code == 200 && !empty($response)) {
+				$json_array = json_decode($response, true);
+				$fetched = [];
+				if (!empty($json_array['data']) && is_array($json_array['data'])) {
+					foreach ($json_array['data'] as $row) {
+						$id = $row['id'] ?? '';
+						if ($id !== '' && strpos($id, 'tts') !== false) {
+							$fetched[$id] = $id;
+						}
+					}
+				}
+				if (!empty($fetched)) {
+					ksort($fetched);
+					$models = $fetched;
+				}
+			}
+		}
+
+		//cache and return
+		$this->models_cache = $models;
+		return $models;
 	}
 
 }

--- a/resources/classes/speech_openai.php
+++ b/resources/classes/speech_openai.php
@@ -191,7 +191,7 @@ class speech_openai implements speech_interface {
 		];
 
 		// set the http data
-		$data['model'] = 'tts-1-hd';
+		$data['model'] = !empty($this->model) ? $this->model : 'tts-1-hd';
 		$data['input'] = $this->message;
 		$data['voice'] = $this->voice;
 		$data['response_format'] = 'wav';
@@ -255,7 +255,8 @@ class speech_openai implements speech_interface {
 
 	public function get_models(): array {
 		return [
-			'tts-1-hd' => 'tts-1-hd'
+			'tts-1-hd' => 'tts-1-hd',
+			'tts-1' => 'tts-1'
 		];
 	}
 


### PR DESCRIPTION
## Summary

Adds the ability to choose the text-to-speech **model** per engine instead of it being hard-coded in each engine class. The model is configured in **Advanced → Default Settings** (`speech / model`, global or per-domain) and flows through to the API request. Where the provider exposes a models API, the list is fetched live.

## Changes

**1. Per-engine model selection**
- Implement the existing `get_models()` / `set_model()` interface methods meaningfully for each engine.
- **Inworld:** real model list (`inworld-tts-2`, `inworld-tts-1.5-max`, `inworld-tts-1.5-mini`) and use the selection in the request (previously hard-coded).
- **OpenAI / Local / ElevenLabs:** honor the selected model, falling back to the previous default when none is set.
- `speech` dispatcher passes the chosen model to the engine via `set_model()`.
- Register a `speech / model` default setting (blank = engine default).

**2. Dynamic model lists where the provider supports it**
- **ElevenLabs:** `GET /v1/models`, keep models flagged `can_do_text_to_speech`.
- **OpenAI:** `GET /v1/models`, keep ids matching `tts` (the models endpoint has no capability flag).
- Results are cached per request to avoid a second call from `set_model()`.
- **Inworld / Local:** keep curated lists — neither exposes a list-models endpoint.

## Behavior & safety
- Model resolution order: explicit selection → `speech/model` default setting → engine's built-in default.
- Every dynamic fetch uses short timeouts (5s total / 3s connect) and falls back to the curated list on any failure, so the dropdown never comes up empty.
- Coexists with the Speed-Control (#4) changes.

## Companion UI (separate repos, to be submitted separately)
The dropdowns that expose this live in other repos:
- **core** `default_settings/default_setting_edit.php` — render `speech/engine` and `speech/model` as dropdowns (the model list is pulled from the selected engine's `get_models()`).
- **fusionpbx-app-recordings** `recording_edit.php` — use the `speech/model` default setting; remove the per-recording model field.

## Testing
- `php -l` passes on all modified files